### PR TITLE
TDATA conversion functionality is not needed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,5 +158,5 @@ wheelhouse/
 
 # Optional: ignore virtualenv wrapper files
 .python-version
-
+uv.lock
 # End

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,7 @@
+# dev dep
+uv.lock
+main.py
+
 # Byte-compiled / optimized / DLL files
 __pycache__/
 *.py[cod]
@@ -158,5 +162,4 @@ wheelhouse/
 
 # Optional: ignore virtualenv wrapper files
 .python-version
-uv.lock
 # End

--- a/TGConvertor/__main__.py
+++ b/TGConvertor/__main__.py
@@ -9,7 +9,7 @@ from rich.table import Table
 
 from .manager import SessionManager
 from .exceptions import ValidationError
-from opentele.api import API
+from .api import API, APIData
 
 
 console = Console()
@@ -53,8 +53,8 @@ class APIType(str, Enum):
     MACOS = "macos"
 
 
-def get_api_type(api: APIType) -> API:
-    """Convert string API type to opentele.API type"""
+def get_api_type(api: APIType) -> APIData:
+    """Convert string API type to API type"""
     return {
         APIType.DESKTOP: API.TelegramDesktop,
         APIType.ANDROID: API.TelegramAndroid,
@@ -251,7 +251,7 @@ async def _convert_universal(
     source: str,
     from_format: SessionFormat,
     to_format: SessionFormat,
-    api: API,
+    api: APIData,
     is_source_file: bool = False,
     want_string_output: bool = False,
     output_path: Optional[str] = None,
@@ -270,7 +270,7 @@ async def _convert_universal(
         elif from_format == SessionFormat.PYROGRAM:
             session = await SessionManager.from_pyrogram_file(source_path, api)
         elif from_format == SessionFormat.TDATA:
-            session = await SessionManager.from_tdata_folder(source_path, api)
+            session = SessionManager.from_tdata_folder(source_path)
         else:
             raise ValidationError(f"Unsupported source format: {from_format}")
     else:

--- a/TGConvertor/api.py
+++ b/TGConvertor/api.py
@@ -1,0 +1,87 @@
+"""
+Telegram API configurations for different platforms.
+Replaces opentele.api functionality.
+"""
+
+
+class APIData:
+    """Telegram API data class for client configuration."""
+    
+    def __init__(
+        self,
+        api_id: int,
+        api_hash: str,
+        device_model: str,
+        system_version: str,
+        app_version: str,
+        lang_code: str = "en",
+        system_lang_code: str = "en-US",
+    ):
+        self.api_id = api_id
+        self.api_hash = api_hash
+        self.device_model = device_model
+        self.system_version = system_version
+        self.app_version = app_version
+        self.lang_code = lang_code
+        self.system_lang_code = system_lang_code
+    
+    def copy(self):
+        """Create a copy of this APIData instance."""
+        return APIData(
+            api_id=self.api_id,
+            api_hash=self.api_hash,
+            device_model=self.device_model,
+            system_version=self.system_version,
+            app_version=self.app_version,
+            lang_code=self.lang_code,
+            system_lang_code=self.system_lang_code,
+        )
+
+
+class API:
+    """Telegram API configurations for different platforms."""
+    
+    # Telegram Desktop
+    TelegramDesktop = APIData(
+        api_id=17349,
+        api_hash="344583e45741c457fe1862106095a5eb",
+        device_model="Desktop",
+        system_version="Windows 10",
+        app_version="4.8.0",
+        lang_code="en",
+        system_lang_code="en-US",
+    )
+    
+    # Telegram Android
+    TelegramAndroid = APIData(
+        api_id=4,
+        api_hash="014b35b6184100b085b0d0572f9b5103",
+        device_model="Android",
+        system_version="SDK 23",
+        app_version="9.7.0",
+        lang_code="en",
+        system_lang_code="en-US",
+    )
+    
+    # Telegram iOS
+    TelegramIOS = APIData(
+        api_id=8,
+        api_hash="7245de8e747a0d6fbe11f7cc14fcc0bb",
+        device_model="iPhone",
+        system_version="iOS 15.0",
+        app_version="9.7.0",
+        lang_code="en",
+        system_lang_code="en-US",
+    )
+    
+    # Telegram macOS
+    TelegramMacOS = APIData(
+        api_id=946,
+        api_hash="5f3fb04eac560c6a3d7dd5cacb85e8b0",
+        device_model="Mac",
+        system_version="macOS 12.0",
+        app_version="9.7.0",
+        lang_code="en",
+        system_lang_code="en-US",
+    )
+

--- a/TGConvertor/sessions/pyro/kuri.py
+++ b/TGConvertor/sessions/pyro/kuri.py
@@ -2,13 +2,13 @@ import base64
 import secrets
 import struct
 import time
-from typing import Type, Union
+from typing import Union
 from pathlib import Path
 
 import aiosqlite
-from opentele.api import APIData
-from pyrogram.client import Client
+from pyrogram.client import Client # type: ignore
 
+from ...api import APIData
 from ...exceptions import ValidationError
 
 # Схема из новой версии Pyrogram
@@ -151,14 +151,6 @@ class PyroSession:
 
     def to_string(self) -> str:
         """Экспортирует сессию в session_string (новый формат)."""
-        print(self.STRING_FORMAT)
-        print(self.dc_id)
-        print(self.api_id)
-        print(self.test_mode)
-        print(self.auth_key)
-        print(self.user_id)
-        print(self.is_bot)
-
         packed = struct.pack(
             self.STRING_FORMAT,
             self.dc_id,
@@ -181,7 +173,9 @@ class PyroSession:
             async with db.execute("SELECT * FROM sessions") as cursor:
                 session = await cursor.fetchone()
 
-        return cls(**session)
+        if session is None:
+            raise ValidationError(f"No session found in: {path}")
+        return cls(**dict(session))
 
     @classmethod
     async def validate(cls, path: Union[Path, str]) -> bool:
@@ -243,7 +237,7 @@ class PyroSession:
             await db.commit()
 
     def client(
-        self, api: Type[APIData], proxy: dict | None = None, no_updates: bool = True
+        self, api: APIData, proxy: dict | None = None, no_updates: bool = True
     ) -> Client:
         """Создает готовый pyrogram.Client на основе этой сессии."""
         return Client(

--- a/TGConvertor/sessions/pyro/pyro.py
+++ b/TGConvertor/sessions/pyro/pyro.py
@@ -1,13 +1,13 @@
 import base64
 import secrets
 import struct
-from typing import Type, Union
+from typing import Union
 from pathlib import Path
 
 import aiosqlite
-from opentele.api import APIData
-from pyrogram.client import Client
+from pyrogram.client import Client # type: ignore
 
+from ...api import APIData
 from ...exceptions import ValidationError
 
 
@@ -122,7 +122,7 @@ class PyroSession:
             async with db.execute("SELECT * FROM sessions") as cursor:
                 session = await cursor.fetchone()
 
-        return cls(**session)
+        return cls(**session) # type: ignore
 
     @classmethod
     async def validate(cls, path: Union[Path, str]) -> bool:
@@ -152,7 +152,7 @@ class PyroSession:
 
     def client(
         self,
-        api: Type[APIData],
+        api: APIData,
         proxy: None | dict = None,
         no_updates: bool = True
     ) -> Client:

--- a/TGConvertor/sessions/tdata.py
+++ b/TGConvertor/sessions/tdata.py
@@ -1,9 +1,19 @@
 from pathlib import Path
-from typing import Type, Union
+from typing import Union
 
-from opentele.api import API, APIData
-from opentele.td import TDesktop, Account, AuthKeyType, AuthKey
-from opentele.td.configs import DcId
+from ..api import API, APIData
+
+try:
+    from opentele.td import TDesktop, Account, AuthKeyType, AuthKey # type: ignore
+    from opentele.td.configs import DcId # type: ignore
+    HAS_OPENTELE_TD = True
+except ImportError:
+    HAS_OPENTELE_TD = False
+    TDesktop = None
+    Account = None
+    AuthKeyType = None
+    AuthKey = None
+    DcId = None
 
 
 class TDataSession:
@@ -13,7 +23,7 @@ class TDataSession:
             dc_id: int,
             auth_key: bytes,
             user_id: int,
-            api: Type[APIData] = API.TelegramDesktop,
+            api: APIData = API.TelegramDesktop,
     ):
         self.dc_id = dc_id
         self.auth_key = auth_key
@@ -22,6 +32,12 @@ class TDataSession:
 
     @classmethod
     def from_tdata(cls, tdata_folder: Union[Path, str]):
+        if not HAS_OPENTELE_TD:
+            raise ImportError(
+                "TData support requires opentele package. "
+                "Please install it with: pip install tgconvertor[tdata] or pip install opentele"
+            )
+        
         tdata_folder = Path(tdata_folder)
         
         if not tdata_folder.exists():
@@ -37,6 +53,13 @@ class TDataSession:
         )
 
     def to_folder(self, path: Union[Path, str]):
+        if not HAS_OPENTELE_TD:
+            raise ImportError(
+                "TData support requires opentele package. "
+                "Please install it with: pip install tgconvertor[tdata] or pip install opentele"
+            )
+        
+        path = Path(path)
         path.mkdir(parents=True, exist_ok=True)
 
         dc_id = DcId(self.dc_id)

--- a/TGConvertor/sessions/tele.py
+++ b/TGConvertor/sessions/tele.py
@@ -2,19 +2,20 @@ import base64
 import ipaddress
 import struct
 from pathlib import Path
-from typing import Type
 
 import aiosqlite
-from opentele.api import APIData
+from telethon import TelegramClient # type: ignore
+from telethon.sessions import StringSession # type: ignore
+
 from . import is_kurigram
 if is_kurigram:
-    from pyrogram.storage.sqlite_storage import PROD
+    from pyrogram.storage.sqlite_storage import PROD # type: ignore
 else:
-    from pyrogram.session.internals.data_center import DataCenter
-from telethon import TelegramClient
-from telethon.sessions import StringSession
+    from pyrogram.session.internals.data_center import DataCenter # type: ignore
 
+from ..api import APIData
 from ..exceptions import ValidationError
+
 
 SCHEMA = """
 CREATE TABLE version (version integer primary key);
@@ -117,7 +118,7 @@ class TeleSession:
                 row = await cursor.fetchone()
                 entities = dict(row) if row else {}
                 
-        return cls(user_id=entities.get('id'), phone_number=entities.get('phone'), **session)
+        return cls(user_id=entities.get('id'), phone_number=entities.get('phone'), **session) # type: ignore
 
     @classmethod
     async def validate(cls, path: Path) -> bool:
@@ -153,7 +154,7 @@ class TeleSession:
 
     def client(
             self,
-            api: Type[APIData],
+            api: APIData,
             proxy: None | dict = None,
             no_updates: bool = True
     ):
@@ -161,7 +162,7 @@ class TeleSession:
             session=StringSession(self.to_string()),
             api_id=api.api_id,
             api_hash=api.api_hash,
-            proxy=proxy,
+            proxy=proxy, # type: ignore
             device_model=api.device_model,
             system_version=api.system_version,
             app_version=api.app_version,
@@ -174,10 +175,10 @@ class TeleSession:
     def to_string(self) -> str:
         if self.server_address is None:
             if is_kurigram:
-                self.server_address = PROD[self.dc_id]
+                self.server_address = PROD[self.dc_id] # type: ignore
                 self.port = 443
             else:
-                self.server_address, self.port = DataCenter(
+                self.server_address, self.port = DataCenter( # type: ignore
                     self.dc_id, False, False, False
                 )
         ip = ipaddress.ip_address(self.server_address).packed
@@ -192,10 +193,10 @@ class TeleSession:
     async def to_file(self, path: Path):
         if self.server_address is None:
             if is_kurigram:
-                self.server_address = PROD[self.dc_id]
+                self.server_address = PROD[self.dc_id] # type: ignore
                 self.port = 443
             else:
-                self.server_address, self.port = DataCenter(
+                self.server_address, self.port = DataCenter( # type: ignore
                     self.dc_id, False, False, False
                 )
         async with aiosqlite.connect(path) as db:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tgconvertor"
-version = "0.1.1"
+version = "0.1.2"
 description = "This module is small util for easy converting Telegram sessions to various formats."
 readme = "README.md"
 requires-python = ">=3.10"
@@ -25,13 +25,13 @@ dependencies = [
     "typer>=0.9.0",
     "rich>=13.0.0",
     "typing-extensions>=4.0.0",
-    "opentele",
     "aiosqlite",
 ]
 
 [project.optional-dependencies]
 pyrogram = ["pyrogram"]
 kurigram = ["kurigram"]
+tdata = ["opentele"]
 
 [project.urls]
 Homepage = "https://github.com/nazar220160/TGConvertor"


### PR DESCRIPTION
This makes it impossible to install `TGConvertor` on ARM systems, even when tdata conversion functionality is not needed. The tdata format is a niche feature that most users don't require, making it unreasonable to block installation for all users.

## Solution

### 1. Removed opentele from core dependencies
- `opentele` is no longer a required dependency
- Moved to optional dependency: `pip install "TGConvertor[tdata]"`

### 2. Created custom API module
- Replaced `opentele.api` with custom `TGConvertor.api` module
- Implements `API` and `APIData` classes with Telegram API configurations
- Supports Desktop, Android, iOS, and macOS platforms
- Maintains full compatibility with existing functionality

### 3. Made tdata support optional
- TData session conversion now requires explicit installation: `pip install tgconvertor[tdata]`
- Graceful error handling when tdata is used without opentele installed
- Clear error messages guide users to install the optional dependency
